### PR TITLE
feat: O try-catch foi refatorado com Java Streams, e o GlobalExceptionHandler agora retorna erros customizados ao front-end, em vez de lançar uma RuntimeException.

### DIFF
--- a/src/main/java/br/com/senior/gestaohospedes/belavista/converters/StringToEnumConverter.java
+++ b/src/main/java/br/com/senior/gestaohospedes/belavista/converters/StringToEnumConverter.java
@@ -1,18 +1,21 @@
 package br.com.senior.gestaohospedes.belavista.converters;
-
 import br.com.senior.gestaohospedes.belavista.entity.StatusReserva;
+import br.com.senior.gestaohospedes.belavista.exception.EnumNaoEncontradoException;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+
 @Component
 public class StringToEnumConverter implements Converter<String, StatusReserva> {
-
   @Override
   public StatusReserva convert(String source) {
-    try {
-      return StatusReserva.valueOf(source.toUpperCase());
-    } catch (IllegalArgumentException e) {
-      return null; // Ou lance uma exceção mais específica
+    if (source == null || source.isEmpty()) {
+      return null;
     }
+    return Arrays.stream(StatusReserva.values())
+        .filter(status -> status.name().equalsIgnoreCase(source))
+        .findFirst()
+        .orElseThrow(() -> new EnumNaoEncontradoException(source));
   }
 }

--- a/src/main/java/br/com/senior/gestaohospedes/belavista/exception/EnumNaoEncontradoException.java
+++ b/src/main/java/br/com/senior/gestaohospedes/belavista/exception/EnumNaoEncontradoException.java
@@ -1,0 +1,12 @@
+package br.com.senior.gestaohospedes.belavista.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class EnumNaoEncontradoException extends BusinessException {
+
+  public EnumNaoEncontradoException(String valor) {
+    super("error.enum.naoEncontrado", valor);
+  }
+}

--- a/src/main/java/br/com/senior/gestaohospedes/belavista/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/senior/gestaohospedes/belavista/exception/GlobalExceptionHandler.java
@@ -76,6 +76,14 @@ public class GlobalExceptionHandler {
         .body(createErrorResponse(HttpStatus.BAD_REQUEST, getMessage(ex), request));
   }
 
+  @ExceptionHandler(EnumNaoEncontradoException.class)
+  public ResponseEntity<ErrorResponseDTO> handleEnumNaoEncontrado(
+      EnumNaoEncontradoException ex, WebRequest request) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(createErrorResponse(HttpStatus.BAD_REQUEST, getMessage(ex), request));
+  }
+
+
   @ExceptionHandler(EntityNotFoundException.class)
   public ResponseEntity<ErrorResponseDTO> handleEntityNotFound(EntityNotFoundException ex, WebRequest request) {
     String message = messageSource.getMessage("entity.not.found", null, LocaleContextHolder.getLocale());

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -15,5 +15,5 @@ error.reserva.sobreposta=O hóspede já possui uma reserva ativa para o período
 error.reserva.cancelamentoInvalido=Apenas reservas com o status PENDENTE podem ser canceladas.
 
 # Mensagens de Validação
-validation.field.notBlank=não pode estar em branco
-validation.field.size=o tamanho deve estar entre {2} e {1}
+error.enum.naoEncontrado=Valor '{0}' inválido para o status da reserva.
+


### PR DESCRIPTION
O try-catch foi substituído por Java Streams, o que torna mais explícita a validação de status do enum StatusReserva. Com isso, o GlobalExceptionHandler passa a retornar o erro customizado ao front-end, em vez de lançar uma RuntimeException.